### PR TITLE
Fix PSMDB 3.3.5 build with rocksdb enabled

### DIFF
--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -85,6 +85,7 @@ namespace mongo {
 
         // used to construct RocksCursors
         const Ordering _order;
+        const KeyString::Version _keyStringVersion;
 
         class StandardBulkBuilder;
         class UniqueBulkBuilder;


### PR DESCRIPTION
Merge commit 9e84856 which is necessary to successfully build PSMDB 3.3.5 with rocksdb enabled
This commit is missing from r3.3.5 tag.