### PR TITLE
SERVER-25156 Add support for building v=2 indexes

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -373,7 +373,7 @@ namespace mongo {
                                                   const IndexDescriptor* desc) {
         BSONObjBuilder configBuilder;
         // let index add its own config things
-        RocksIndexBase::generateConfig(&configBuilder, _formatVersion);
+        RocksIndexBase::generateConfig(&configBuilder, _formatVersion, desc->version());
         return _createIdent(ident, &configBuilder);
     }
 

--- a/src/rocks_index.cpp
+++ b/src/rocks_index.cpp
@@ -602,8 +602,9 @@ namespace mongo {
             std::max(_indexStorageSize.load(std::memory_order_relaxed), static_cast<long long>(1)));
     }
 
-    void RocksIndexBase::generateConfig(BSONObjBuilder* configBuilder, int formatVersion) {
-        if (formatVersion >= 3) {
+    void RocksIndexBase::generateConfig(BSONObjBuilder* configBuilder, int formatVersion,
+                                        IndexDescriptor::IndexVersion descVersion) {
+        if (formatVersion >= 3 && descVersion >= IndexDescriptor::IndexVersion::kV2) {
           configBuilder->append("index_format_version", static_cast<int32_t>(kMaximumIndexVersion));
         } else {
           // keep it backwards compatible

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -35,6 +35,7 @@
 #include <rocksdb/db.h>
 
 #include "mongo/bson/ordering.h"
+#include "mongo/db/index/index_descriptor.h"
 #include "mongo/db/storage/key_string.h"
 
 #pragma once
@@ -72,7 +73,8 @@ namespace mongo {
 
         virtual long long getSpaceUsedBytes( OperationContext* txn ) const;
 
-        static void generateConfig(BSONObjBuilder* configBuilder, int formatVersion);
+        static void generateConfig(BSONObjBuilder* configBuilder, int formatVersion,
+                                   IndexDescriptor::IndexVersion descVersion);
 
     protected:
         static std::string _makePrefixedKey(const std::string& prefix, const KeyString& encodedKey);

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -68,7 +68,7 @@ namespace mongo {
 
         std::unique_ptr<SortedDataInterface> newSortedDataInterface(bool unique) {
             BSONObjBuilder configBuilder;
-            RocksIndexBase::generateConfig(&configBuilder, 3);
+            RocksIndexBase::generateConfig(&configBuilder, 3, IndexDescriptor::IndexVersion::kV2);
             if (unique) {
                 return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order,
                                                            configBuilder.obj());


### PR DESCRIPTION
Allows to pass noPassthrough/index_version_v2.js test for MongoRocks.