### PR TITLE
PSMDB-86 make rocksdb counters enabled by default

### DIFF
--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -80,7 +80,7 @@ namespace mongo {
                                "rocksdbCounters",
                                moe::Bool,
                                "If true, we will turn on RocksDB's advanced counters")
-            .setDefault(moe::Value(false));
+            .setDefault(moe::Value(true));
         rocksOptions
             .addOptionChaining("storage.rocksdb.singleDeleteIndex",
                                "rocksdbSingleDeleteIndex", moe::Bool,


### PR DESCRIPTION
I'm not sure it is good idea to change this default in minor release.