### PR TITLE
PSMDB-126 Add index and collection name in dup key error message

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -393,10 +393,10 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), prefix, ident.toString(),
-                                         Ordering::make(desc->keyPattern()), std::move(config));
+                                         desc, std::move(config));
         } else {
             auto si = new RocksStandardIndex(_db.get(), prefix, ident.toString(),
-                                             Ordering::make(desc->keyPattern()), std::move(config));
+                                             desc, std::move(config));
             if (rocksGlobalOptions.singleDeleteIndex) {
                 si->enableSingleDelete();
             }

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -393,10 +393,11 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), prefix, ident.toString(),
-                                         desc, std::move(config));
+                                         Ordering::make(desc->keyPattern()), std::move(config),
+                                         desc->parentNS(), desc->indexName());
         } else {
             auto si = new RocksStandardIndex(_db.get(), prefix, ident.toString(),
-                                             desc, std::move(config));
+                                             Ordering::make(desc->keyPattern()), std::move(config));
             if (rocksGlobalOptions.singleDeleteIndex) {
                 si->enableSingleDelete();
             }

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -52,7 +52,7 @@ namespace mongo {
         MONGO_DISALLOW_COPYING(RocksIndexBase);
 
     public:
-        RocksIndexBase(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+        RocksIndexBase(rocksdb::DB* db, std::string prefix, std::string ident, const IndexDescriptor* desc,
                        const BSONObj& config);
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
@@ -76,6 +76,8 @@ namespace mongo {
         static void generateConfig(BSONObjBuilder* configBuilder, int formatVersion,
                                    IndexDescriptor::IndexVersion descVersion);
 
+        std::string dupKeyError(const BSONObj& key);
+
     protected:
         static std::string _makePrefixedKey(const std::string& prefix, const KeyString& encodedKey);
 
@@ -91,6 +93,8 @@ namespace mongo {
         // used to construct RocksCursors
         const Ordering _order;
         KeyString::Version _keyStringVersion;
+        std::string _collectionNamespace;
+        std::string _indexName;
 
         class StandardBulkBuilder;
         class UniqueBulkBuilder;
@@ -99,7 +103,7 @@ namespace mongo {
 
     class RocksUniqueIndex : public RocksIndexBase {
     public:
-        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, const IndexDescriptor* desc,
                          const BSONObj& config);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
@@ -117,7 +121,7 @@ namespace mongo {
 
     class RocksStandardIndex : public RocksIndexBase {
     public:
-        RocksStandardIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+        RocksStandardIndex(rocksdb::DB* db, std::string prefix, std::string ident, const IndexDescriptor* desc,
                            const BSONObj& config);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -54,7 +54,7 @@ namespace mongo {
 
     class RocksIndexHarness final : public HarnessHelper {
     public:
-        RocksIndexHarness() : _tempDir(_testNamespace) {
+        RocksIndexHarness() : _order(Ordering::make(BSONObj())), _tempDir(_testNamespace) {
             boost::filesystem::remove_all(_tempDir.path());
             rocksdb::DB* db;
             rocksdb::Options options;
@@ -69,19 +69,12 @@ namespace mongo {
         std::unique_ptr<SortedDataInterface> newSortedDataInterface(bool unique) {
             BSONObjBuilder configBuilder;
             RocksIndexBase::generateConfig(&configBuilder, 3, IndexDescriptor::IndexVersion::kV2);
-
-            BSONObj spec = BSON("key" << BSON("a" << 1) << "name"
-                                      << "testIndex"
-                                      << "ns"
-                                      << "test.rocks");
-
-            IndexDescriptor desc(NULL, "", spec);
-
             if (unique) {
-                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", &desc,
-                                                           configBuilder.obj());
+                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order,
+                                                           configBuilder.obj(), "test.rocks",
+                                                           "testIndex");
             } else {
-                return stdx::make_unique<RocksStandardIndex>(_db.get(), "prefix", "ident", &desc,
+                return stdx::make_unique<RocksStandardIndex>(_db.get(), "prefix", "ident", _order,
                                                              configBuilder.obj());
             }
         }
@@ -93,6 +86,7 @@ namespace mongo {
         }
 
     private:
+        Ordering _order;
         string _testNamespace = "mongo-rocks-sorted-data-test";
         unittest::TempDir _tempDir;
         std::unique_ptr<rocksdb::DB> _db;


### PR DESCRIPTION
Same issue was fixed for WiredTiger (SERVER-17532). Without this fix it is not possible to identify which field in the inserted document causes duplicate error.