### PR TITLE
PSMDB-126 Add index and collection name in dup key error message

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -393,7 +393,8 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), prefix, ident.toString(),
-                                         Ordering::make(desc->keyPattern()), std::move(config));
+                                         Ordering::make(desc->keyPattern()), std::move(config),
+                                         desc->parentNS(), desc->indexName());
         } else {
             auto si = new RocksStandardIndex(_db.get(), prefix, ident.toString(),
                                              Ordering::make(desc->keyPattern()), std::move(config));

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -100,7 +100,8 @@ namespace mongo {
     class RocksUniqueIndex : public RocksIndexBase {
     public:
         RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
-                         const BSONObj& config);
+                         const BSONObj& config, std::string collectionNamespace,
+                         std::string indexName);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                               bool dupsAllowed);
@@ -113,6 +114,9 @@ namespace mongo {
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                            bool dupsAllowed) override;
+    private:
+        std::string _collectionNamespace;
+        std::string _indexName;
     };
 
     class RocksStandardIndex : public RocksIndexBase {

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -71,7 +71,8 @@ namespace mongo {
             RocksIndexBase::generateConfig(&configBuilder, 3, IndexDescriptor::IndexVersion::kV2);
             if (unique) {
                 return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order,
-                                                           configBuilder.obj());
+                                                           configBuilder.obj(), "test.rocks",
+                                                           "testIndex");
             } else {
                 return stdx::make_unique<RocksStandardIndex>(_db.get(), "prefix", "ident", _order,
                                                              configBuilder.obj());


### PR DESCRIPTION
Same issue was fixed for WiredTiger (SERVER-17532). Without this fix it is not possible to identify which field in the inserted document causes duplicate error.