### PR TITLE
PSMDB-126 Add index and collection name in dup key error message

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -374,7 +374,8 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
-                                         Ordering::make(desc->keyPattern()));
+                                         Ordering::make(desc->keyPattern()), desc->parentNS(),
+                                         desc->indexName());
         } else {
             auto si = new RocksStandardIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
                                              Ordering::make(desc->keyPattern()));

--- a/src/rocks_index.cpp
+++ b/src/rocks_index.cpp
@@ -76,10 +76,13 @@ namespace mongo {
             return b.obj();
         }
 
-        string dupKeyError(const BSONObj& key) {
+        string dupKeyError(const BSONObj& key, const std::string& collectionNamespace,
+                           const std::string& indexName) {
             stringstream ss;
-            ss << "E11000 duplicate key error ";
-            ss << "dup key: " << key.toString();
+            ss << "E11000 duplicate key error";
+            ss << " collection: " << collectionNamespace;
+            ss << " index: " << indexName;
+            ss << " dup key: " << key.toString();
             return ss.str();
         }
 
@@ -444,10 +447,14 @@ namespace mongo {
     public:
         UniqueBulkBuilder(std::string prefix,
                           Ordering ordering,
+                          std::string collectionNamespace,
+                          std::string indexName,
                           OperationContext* txn,
                           bool dupsAllowed)
             : _prefix(std::move(prefix)),
               _ordering(ordering),
+              _collectionNamespace(std::move(collectionNamespace)),
+              _indexName(std::move(indexName)),
               _txn(txn),
               _dupsAllowed(dupsAllowed) {}
 
@@ -469,7 +476,7 @@ namespace mongo {
             else {
                 // Dup found!
                 if (!_dupsAllowed) {
-                    return Status(ErrorCodes::DuplicateKey, dupKeyError(newKey));
+                    return Status(ErrorCodes::DuplicateKey, dupKeyError(newKey, _collectionNamespace, _indexName));
                 }
 
                 // If we get here, we are in the weird mode where dups are allowed on a unique
@@ -518,6 +525,8 @@ namespace mongo {
 
         std::string _prefix;
         Ordering _ordering;
+        std::string _collectionNamespace;
+        std::string _indexName;
         OperationContext* _txn;
         const bool _dupsAllowed;
         BSONObj _key;
@@ -583,8 +592,11 @@ namespace mongo {
     /// RocksUniqueIndex
 
     RocksUniqueIndex::RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident,
-                                       Ordering order)
-        : RocksIndexBase(db, prefix, ident, order) {}
+                                       Ordering order, std::string collectionNamespace,
+                                       std::string indexName)
+        : RocksIndexBase(db, prefix, ident, order),
+          _collectionNamespace(std::move(collectionNamespace)),
+          _indexName(std::move(indexName)) {}
 
     Status RocksUniqueIndex::insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                                     bool dupsAllowed) {
@@ -645,7 +657,7 @@ namespace mongo {
         }
 
         if (!dupsAllowed) {
-            return Status(ErrorCodes::DuplicateKey, dupKeyError(key));
+            return Status(ErrorCodes::DuplicateKey, dupKeyError(key, _collectionNamespace, _indexName));
         }
 
         if (!insertedLoc) {
@@ -774,12 +786,13 @@ namespace mongo {
 
             KeyString::TypeBits::fromBuffer(&br);  // Just calling this to advance reader.
         }
-        return Status(ErrorCodes::DuplicateKey, dupKeyError(key));
+        return Status(ErrorCodes::DuplicateKey, dupKeyError(key, _collectionNamespace, _indexName));
     }
 
     SortedDataBuilderInterface* RocksUniqueIndex::getBulkBuilder(OperationContext* txn,
                                                                  bool dupsAllowed) {
-        return new RocksIndexBase::UniqueBulkBuilder(_prefix, _order, txn, dupsAllowed);
+        return new RocksIndexBase::UniqueBulkBuilder(_prefix, _order, _collectionNamespace,
+                                                     _indexName, txn, dupsAllowed);
     }
 
     /// RocksStandardIndex

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -93,7 +93,8 @@ namespace mongo {
 
     class RocksUniqueIndex : public RocksIndexBase {
     public:
-        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order);
+        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+                         std::string collectionNamespace, std::string indexName);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                               bool dupsAllowed);
@@ -106,6 +107,9 @@ namespace mongo {
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                            bool dupsAllowed) override;
+    private:
+        std::string _collectionNamespace;
+        std::string _indexName;
     };
 
     class RocksStandardIndex : public RocksIndexBase {

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -68,7 +68,8 @@ namespace mongo {
 
         std::unique_ptr<SortedDataInterface> newSortedDataInterface(bool unique) {
             if (unique) {
-                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order);
+                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order,
+                                                           "test.rocks", "testIndex");
             } else {
                 return stdx::make_unique<RocksStandardIndex>(_db.get(), "prefix", "ident", _order);
             }


### PR DESCRIPTION
Same issue was fixed for WiredTiger (SERVER-17532). Without this fix it is not possible to identify which field in the inserted document causes duplicate error.