### PR TITLE
Merge r3.2.13

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -27,6 +27,7 @@ env.Library(
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/namespace_string',
         '$BUILD_DIR/mongo/db/catalog/collection_options',
+        '$BUILD_DIR/mongo/db/concurrency/lock_manager',
         '$BUILD_DIR/mongo/db/concurrency/write_conflict_exception',
         '$BUILD_DIR/mongo/db/index/index_descriptor',
         '$BUILD_DIR/mongo/db/storage/bson_collection_catalog_entry',

--- a/SConscript
+++ b/SConscript
@@ -69,6 +69,8 @@ env.Library(
         ],
     LIBDEPS= [
         'storage_rocks_base',
+        # Temporary crutch since the ssl cleanup is hard coded in background.cpp
+        '$BUILD_DIR/mongo/util/net/network',
         ]
     )
 

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -67,6 +67,7 @@
 
 #include "rocks_counter_manager.h"
 #include "rocks_global_options.h"
+#include "rocks_parameters.h"
 #include "rocks_record_store.h"
 #include "rocks_recovery_unit.h"
 #include "rocks_index.h"
@@ -189,6 +190,14 @@ namespace mongo {
         private:
             const RocksEngine* _engine;
         };
+        
+        TicketHolder openWriteTransaction(128);
+        RocksTicketServerParameter openWriteTransactionParam(&openWriteTransaction,
+                                                        "rocksdbConcurrentWriteTransactions");
+
+        TicketHolder openReadTransaction(128);
+        RocksTicketServerParameter openReadTransactionParam(&openReadTransaction,
+                                                       "rocksdbConcurrentReadTransactions");
 
     }  // anonymous namespace
 
@@ -312,10 +321,31 @@ namespace mongo {
             _journalFlusher = stdx::make_unique<RocksJournalFlusher>(_durabilityManager.get());
             _journalFlusher->go();
         }
+        
+        Locker::setGlobalThrottling(&openReadTransaction, &openWriteTransaction);
     }
 
     RocksEngine::~RocksEngine() { cleanShutdown(); }
 
+    void RocksEngine::appendGlobalStats(BSONObjBuilder& b) {
+        BSONObjBuilder bb(b.subobjStart("concurrentTransactions"));
+        {
+            BSONObjBuilder bbb(bb.subobjStart("write"));
+            bbb.append("out", openWriteTransaction.used());
+            bbb.append("available", openWriteTransaction.available());
+            bbb.append("totalTickets", openWriteTransaction.outof());
+            bbb.done();
+        }
+        {
+            BSONObjBuilder bbb(bb.subobjStart("read"));
+            bbb.append("out", openReadTransaction.used());
+            bbb.append("available", openReadTransaction.available());
+            bbb.append("totalTickets", openReadTransaction.outof());
+            bbb.done();
+        }
+        bb.done();
+    }
+    
     RecoveryUnit* RocksEngine::newRecoveryUnit() {
         return new RocksRecoveryUnit(&_transactionEngine, &_snapshotManager, _db.get(),
                                      _counterManager.get(), _compactionScheduler.get(),

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -196,7 +196,7 @@ namespace mongo {
         private:
             const RocksEngine* _engine;
         };
-        
+
         // ServerParameter to limit concurrency, to prevent thousands of threads running
         // concurrent searches and thus blocking the entire DB.
         class RocksTicketServerParameter : public ServerParameter {
@@ -229,7 +229,7 @@ namespace mongo {
 
                 return _holder->resize(newNum);
             }
-            
+
             TicketHolder* _holder;
         };
 
@@ -446,7 +446,8 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
-                                         Ordering::make(desc->keyPattern()));
+                                         Ordering::make(desc->keyPattern()), desc->isPartial());
+
         } else {
             auto si = new RocksStandardIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
                                              Ordering::make(desc->keyPattern()));

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -75,6 +75,8 @@ namespace mongo {
     public:
         RocksEngine(const std::string& path, bool durable);
         virtual ~RocksEngine();
+        
+        static void appendGlobalStats(BSONObjBuilder& b);
 
         virtual RecoveryUnit* newRecoveryUnit() override;
 

--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -80,7 +80,7 @@ namespace mongo {
                                "rocksdbCounters",
                                moe::Bool,
                                "If true, we will turn on RocksDB's advanced counters")
-            .setDefault(moe::Value(false));
+            .setDefault(moe::Value(true));
         rocksOptions
             .addOptionChaining("storage.rocksdb.singleDeleteIndex",
                                "rocksdbSingleDeleteIndex", moe::Bool,

--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -80,7 +80,7 @@ namespace mongo {
                                "rocksdbCounters",
                                moe::Bool,
                                "If true, we will turn on RocksDB's advanced counters")
-            .setDefault(moe::Value(true));
+            .setDefault(moe::Value(false));
         rocksOptions
             .addOptionChaining("storage.rocksdb.singleDeleteIndex",
                                "rocksdbSingleDeleteIndex", moe::Bool,

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -93,7 +93,8 @@ namespace mongo {
 
     class RocksUniqueIndex : public RocksIndexBase {
     public:
-        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order);
+        RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+                         bool partial = false);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                               bool dupsAllowed);
@@ -106,6 +107,8 @@ namespace mongo {
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                            bool dupsAllowed) override;
+    private:
+        const bool _partial;
     };
 
     class RocksStandardIndex : public RocksIndexBase {

--- a/src/rocks_init.cpp
+++ b/src/rocks_init.cpp
@@ -62,6 +62,7 @@ namespace mongo {
                 auto leaked3 __attribute__((unused)) = new RocksBackupServerParameter(engine);
                 auto leaked4 __attribute__((unused)) = new RocksCompactServerParameter(engine);
                 auto leaked5 __attribute__((unused)) = new RocksCacheSizeParameter(engine);
+                auto leaked6 __attribute__((unused)) = new RocksOptionsParameter(engine);
 
                 return new KVStorageEngine(engine, options);
             }

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -33,7 +33,6 @@
 #include "rocks_util.h"
 
 #include "mongo/logger/parse_log_component_settings.h"
-#include "mongo/util/concurrency/ticketholder.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
 
@@ -215,34 +214,5 @@ namespace mongo {
 #else
         return Status(ErrorCodes::BadValue, "This action is supported for RocksDB 4.13 and up");
 #endif
-    }
-
-    RocksTicketServerParameter::RocksTicketServerParameter(TicketHolder* holder, const std::string& name)
-        : ServerParameter(ServerParameterSet::getGlobal(), name, true, true), _holder(holder) {}
-
-    void RocksTicketServerParameter::append(OperationContext* txn, BSONObjBuilder& b, const std::string& name) {
-        b.append(name, _holder->outof());
-    }
-
-    Status RocksTicketServerParameter::set(const BSONElement& newValueElement) {
-        if (!newValueElement.isNumber())
-            return Status(ErrorCodes::BadValue, str::stream() << name() << " has to be a number");
-        return _set(newValueElement.numberInt());
-    }
-
-    Status RocksTicketServerParameter::setFromString(const std::string& str) {
-        int num = 0;
-        Status status = parseNumberFromString(str, &num);
-        if (!status.isOK())
-            return status;
-        return _set(num);
-    }
-
-    Status RocksTicketServerParameter::_set(int newNum) {
-        if (newNum <= 0) {
-            return Status(ErrorCodes::BadValue, str::stream() << name() << " has to be > 0");
-        }
-
-        return _holder->resize(newNum);
     }
 }

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -36,9 +36,12 @@
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
 
+#include <rocksdb/status.h>
 #include <rocksdb/cache.h>
 #include <rocksdb/experimental.h>
 #include <rocksdb/db.h>
+#include <rocksdb/convenience.h>
+#include <rocksdb/options.h>
 
 namespace mongo {
 
@@ -150,6 +153,61 @@ namespace mongo {
         size_t newSizeInBytes = static_cast<size_t>(newNum * bytesInGB);
         _engine->getBlockCache()->SetCapacity(newSizeInBytes);
 
+        return Status::OK();
+    }    
+    
+    RocksOptionsParameter::RocksOptionsParameter(RocksEngine* engine)
+        : ServerParameter(ServerParameterSet::getGlobal(), "rocksdbOptions", false,
+                          true),
+          _engine(engine) {}
+
+    void RocksOptionsParameter::append(OperationContext* txn, BSONObjBuilder& b,
+                                         const std::string& name) {
+        std::string columnOptions;
+        std::string dbOptions;
+        std::string fullOptionsStr;
+        rocksdb::Options fullOptions = _engine->getDB()->GetOptions();
+        rocksdb::Status s = GetStringFromColumnFamilyOptions(&columnOptions, fullOptions);
+        if (!s.ok()) { // If we failed, append the error for the user to see.
+            b.append(name, s.ToString()); 
+            return;
+        }
+        
+        fullOptionsStr.append(columnOptions);
+        
+        s = GetStringFromDBOptions(&dbOptions, fullOptions);
+        if (!s.ok()) { // If we failed, append the error for the user to see.
+            b.append(name, s.ToString()); 
+            return;
+        }
+        
+        fullOptionsStr.append(dbOptions);
+
+        b.append(name, fullOptionsStr);
+    }
+
+    Status RocksOptionsParameter::set(const BSONElement& newValueElement) {        
+        // In case the BSON element is not a string, the conversion will fail, 
+        // raising an exception catched by the outer layer.
+        // Which will generate an error message that looks like this:
+        // wrong type for field (rocksdbOptions) 3 != 2        
+        return setFromString(newValueElement.String());
+    }
+
+    Status RocksOptionsParameter::setFromString(const std::string& str) {
+        log() << "RocksDB: Attempting to apply settings: " << str;
+        
+        std::unordered_map<std::string, std::string> optionsMap;
+        rocksdb::Status s = rocksdb::StringToMap(str, &optionsMap);
+        if (!s.ok()) {
+            return Status(ErrorCodes::BadValue, s.ToString());
+        }
+        
+        s = _engine->getDB()->SetOptions(optionsMap);
+        if (!s.ok()) {
+            return Status(ErrorCodes::BadValue, s.ToString());
+        }
+        
         return Status::OK();
     }
 }

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -43,6 +43,7 @@
 #include <rocksdb/db.h>
 #include <rocksdb/convenience.h>
 #include <rocksdb/options.h>
+#include <rocksdb/version.h>
 
 namespace mongo {
 
@@ -196,6 +197,7 @@ namespace mongo {
     }
 
     Status RocksOptionsParameter::setFromString(const std::string& str) {
+#if defined(ROCKSDB_MAJOR) && (ROCKSDB_MAJOR > 4 || (ROCKSDB_MAJOR == 4 && ROCKSDB_MINOR >= 13))        
         log() << "RocksDB: Attempting to apply settings: " << str;
         
         std::unordered_map<std::string, std::string> optionsMap;
@@ -210,6 +212,9 @@ namespace mongo {
         }
         
         return Status::OK();
+#else
+        return Status(ErrorCodes::BadValue, "This action is supported for RocksDB 4.13 and up");
+#endif
     }
 
     RocksTicketServerParameter::RocksTicketServerParameter(TicketHolder* holder, const std::string& name)

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -99,4 +99,21 @@ namespace mongo {
         Status _set(int newNum);
         RocksEngine* _engine;
     };
+    
+    
+    // We use mongo's setParameter() API to dynamically change the RocksDB options using the SetOptions API
+    // To dynamically change an option, call:
+    // db.adminCommand({setParameter:1, "rocksdbOptions": "someoption=1; someoption2=3"})
+    class RocksOptionsParameter : public ServerParameter {
+        MONGO_DISALLOW_COPYING(RocksOptionsParameter);
+
+    public:
+        RocksOptionsParameter(RocksEngine* engine);
+        virtual void append(OperationContext* txn, BSONObjBuilder& b, const std::string& name);
+        virtual Status set(const BSONElement& newValueElement);
+        virtual Status setFromString(const std::string& str);
+
+    private:
+        RocksEngine* _engine;
+    };
 }

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -28,7 +28,6 @@
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/db/server_parameters.h"
-#include "mongo/util/concurrency/ticketholder.h"
 
 #include "rocks_engine.h"
 
@@ -116,21 +115,5 @@ namespace mongo {
 
     private:
         RocksEngine* _engine;
-    };
-    
-    // ServerParameter to limit concurrency, to prevent thousands of threads running
-    // concurrent searches and thus blocking the entire DB.
-    class RocksTicketServerParameter : public ServerParameter {
-        MONGO_DISALLOW_COPYING(RocksTicketServerParameter);
-
-    public:
-        RocksTicketServerParameter(TicketHolder* holder, const std::string& name);
-        virtual void append(OperationContext* txn, BSONObjBuilder& b, const std::string& name);
-        virtual Status set(const BSONElement& newValueElement);
-        virtual Status setFromString(const std::string& str);
-
-    private:
-        Status _set(int newNum);
-        TicketHolder* _holder;
     };
 }

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -257,6 +257,7 @@ namespace mongo {
         }
         void deleteKey(RocksRecoveryUnit* ru, const RecordId& loc) {
             ru->writeBatch()->Delete(RocksRecordStore::_makePrefixedKey(_prefix, loc));
+            _deletedKeysSinceCompaction++;
         }
         rocksdb::Iterator* newIterator(RocksRecoveryUnit* ru) {
             return ru->NewIterator(_prefix, true);
@@ -265,9 +266,16 @@ namespace mongo {
             uint32_t size =
                 endian::littleToNative(*reinterpret_cast<const uint32_t*>(value.data()));
             return static_cast<int>(size);
+        }        
+        void resetDeletedSinceCompaction() {
+            _deletedKeysSinceCompaction = 0;
         }
+        long long getDeletedSinceCompaction() {
+            return _deletedKeysSinceCompaction;
+        }        
 
     private:
+        std::atomic<long long> _deletedKeysSinceCompaction;
         std::string _prefix;
     };
 
@@ -613,8 +621,10 @@ namespace mongo {
         txn->setRecoveryUnit(realRecoveryUnit, realRUstate);
 
         if (_isOplog) {
-            if (_oplogSinceLastCompaction.minutes() >= kOplogCompactEveryMins) {
-                log() << "Scheduling oplog compactions";
+            if ((_oplogSinceLastCompaction.minutes() >= kOplogCompactEveryMins) || 
+            (_oplogKeyTracker->getDeletedSinceCompaction() >= kOplogCompactEveryDeletedRecords)) {
+                log() << "Scheduling oplog compactions. time since last " << _oplogSinceLastCompaction.minutes() <<
+                    " deleted since last " << _oplogKeyTracker->getDeletedSinceCompaction();
                 _oplogSinceLastCompaction.reset();
                 // schedule compaction for oplog
                 std::string oldestAliveKey(_makePrefixedKey(_prefix, _cappedOldestKeyHint));
@@ -627,6 +637,8 @@ namespace mongo {
                 begin = rocksdb::Slice(oplogKeyTrackerPrefix);
                 end = rocksdb::Slice(oldestAliveKey);
                 rocksdb::experimental::SuggestCompactRange(_db, &begin, &end);
+                
+                _oplogKeyTracker->resetDeletedSinceCompaction();
             }
         }
 

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -292,6 +292,8 @@ namespace mongo {
         Timer _oplogSinceLastCompaction;
         // compact oplog every 30 min
         static const int kOplogCompactEveryMins = 30;
+        // compact oplog every 500K deletes
+        static const int kOplogCompactEveryDeletedRecords = 500000;
 
         // invariant: there is no live records earlier than _cappedOldestKeyHint. There might be
         // some records that are dead after _cappedOldestKeyHint.

--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -203,6 +203,8 @@ namespace mongo {
 
           bob.append("counters", countersObjBuilder.obj());
         }
+        
+        RocksEngine::appendGlobalStats(bob);
 
         return bob.obj();
     }


### PR DESCRIPTION
`rocksdbCounters` is reverted to keep `false` by default in v3.2

Test run: http://jenkins.percona.com/view/PSMDB-3.2/job/percona-server-for-mongodb-3.2-param/48/