### PR TITLE
PSMDB-139 Improve compaction implementation

### DIFF
--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -441,7 +441,8 @@ namespace mongo {
                 kSkippedDeletionsThreshold) {
                 log() << "Compacting dropped prefixes markers";
                 _droppedPrefixesCount.store(0, std::memory_order_relaxed);
-                compactPrefix(kDroppedPrefix);
+                // Let's compact the full default (system) prefix 0.
+                compactPrefix(encodePrefix(0));
             }
         }
     }

--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -215,7 +215,7 @@ namespace mongo {
             }
         }
         lk.unlock();
-        LOG(1) << "compaction thread terminating" << std::endl;
+        LOG(1) << "Compaction thread terminating" << std::endl;
     }
 
     void CompactionBackgroundJob::scheduleCompactOp(const std::string& begin,
@@ -234,7 +234,7 @@ namespace mongo {
         rocksdb::Slice* start = !op._start_str.empty() ? &start_slice : nullptr;
         rocksdb::Slice* end = !op._end_str.empty() ? &end_slice : nullptr;
 
-        LOG(1) << "starting compaction of range: "
+        LOG(1) << "Starting compaction of range: "
               << (start ? start->ToString(true) : "<begin>") << " .. "
               << (end ? end->ToString(true) : "<end>")
               << " (rangeDropped is " << op._rangeDropped << ")";
@@ -242,7 +242,7 @@ namespace mongo {
         if (op._rangeDropped) {
             auto s = rocksdb::DeleteFilesInRange(_db, _db->DefaultColumnFamily(), start, end);
             if (!s.ok()) {
-                log() << "failed to delete files in range: " << s.ToString();
+                log() << "Failed to delete files in compacted range: " << s.ToString();
             }
         }
 
@@ -251,7 +251,7 @@ namespace mongo {
         compact_options.exclusive_manual_compaction = false;
         auto s = _db->CompactRange(compact_options, start, end);
         if (!s.ok()) {
-            log() << "failed to compact range: " << s.ToString();
+            log() << "Failed to compact range: " << s.ToString();
         }
 
         _compactionScheduler->notifyCompacted(op._start_str, op._end_str, op._rangeDropped, s.ok());
@@ -341,7 +341,7 @@ namespace mongo {
                 stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
                 _droppedPrefixes.insert(int_prefix);
             }
-            LOG(1) << "compacting dropped prefix: " << prefix.ToString(true);
+            LOG(1) << "Compacting dropped prefix: " << prefix.ToString(true);
             compactDroppedPrefix(prefix.ToString());
         }
         log() << dropped_count << " dropped prefixes need compaction";

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -39,6 +39,7 @@
 #include "mongo/util/timer.h"
 
 namespace rocksdb {
+    class CompactionFilterFactory;
     class DB;
     class Iterator;
     class WriteOptions;
@@ -51,8 +52,10 @@ namespace mongo {
 
     class RocksCompactionScheduler {
     public:
-        RocksCompactionScheduler(rocksdb::DB* db);
+        RocksCompactionScheduler();
         ~RocksCompactionScheduler();
+
+        void start(rocksdb::DB* db);
 
         static int getSkippedDeletionsThreshold() { return kSkippedDeletionsThreshold; }
 
@@ -63,6 +66,7 @@ namespace mongo {
         Status compactRange(const std::string& begin, const std::string& end);
         Status compactPrefix(const std::string& prefix);
 
+        rocksdb::CompactionFilterFactory* createCompactionFilterFactory() const;
         std::unordered_set<uint32_t> getDroppedPrefixes() const;
         void loadDroppedPrefixes(rocksdb::Iterator* iter);
         Status dropPrefixesAtomic(const std::vector<std::string>& prefixesToDrop,

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -72,12 +72,13 @@ namespace mongo {
         Status dropPrefixesAtomic(const std::vector<std::string>& prefixesToDrop,
                                   const rocksdb::WriteOptions& syncOptions,
                                   rocksdb::WriteBatch& wb);
+        void notifyCompacted(const std::string& begin, const std::string& end, bool rangeDropped,
+                             bool opSucceeded);
 
     private:
-        void compactDroppedRange(const std::string& begin, const std::string& end,
-                                 const std::function<void(bool)>& cleanup);
-        void compactDroppedPrefix(const std::string& prefix,
-                                  const std::function<void(bool)>& cleanup);
+        void compactDroppedRange(const std::string& begin, const std::string& end);
+        void compactDroppedPrefix(const std::string& prefix);
+        void droppedPrefixCompacted(const std::string& prefix, bool opSucceeded);
 
     private:
         stdx::mutex _lock;

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -62,9 +62,9 @@ namespace mongo {
         void reportSkippedDeletionsAboveThreshold(const std::string& prefix);
 
         // schedule compact range operation for execution in _compactionThread
-        Status compactAll();
-        Status compactRange(const std::string& begin, const std::string& end);
-        Status compactPrefix(const std::string& prefix);
+        void compactAll();
+        void compactRange(const std::string& begin, const std::string& end);
+        void compactPrefix(const std::string& prefix);
 
         rocksdb::CompactionFilterFactory* createCompactionFilterFactory() const;
         std::unordered_set<uint32_t> getDroppedPrefixes() const;
@@ -74,9 +74,10 @@ namespace mongo {
                                   rocksdb::WriteBatch& wb);
 
     private:
-        Status compactDroppedRange(const std::string& begin, const std::string& end,
-                                   const std::function<void(bool)>& cleanup);
-        Status compactDroppedPrefix(const std::string& prefix, const std::function<void(bool)>& cleanup);
+        void compactDroppedRange(const std::string& begin, const std::string& end,
+                                 const std::function<void(bool)>& cleanup);
+        void compactDroppedPrefix(const std::string& prefix,
+                                  const std::function<void(bool)>& cleanup);
 
     private:
         stdx::mutex _lock;

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -64,8 +64,7 @@ namespace mongo {
 
         // schedule compact range operation for execution in _compactionThread
         void compactAll();
-        void compactRange(const std::string& begin, const std::string& end);
-        void compactPrefix(const std::string& prefix);
+        void compactOplog(const std::string& begin, const std::string& end);
 
         rocksdb::CompactionFilterFactory* createCompactionFilterFactory() const;
         std::unordered_set<uint32_t> getDroppedPrefixes() const;
@@ -77,8 +76,10 @@ namespace mongo {
                              bool opSucceeded);
 
     private:
-        void compactDroppedRange(const std::string& begin, const std::string& end);
+        void compactPrefix(const std::string& prefix);
         void compactDroppedPrefix(const std::string& prefix);
+        void compact(const std::string& begin, const std::string& end, bool rangeDropped,
+                     uint32_t order);
         void droppedPrefixCompacted(const std::string& prefix, bool opSucceeded);
 
     private:

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
@@ -99,6 +100,7 @@ namespace mongo {
         // set of all prefixes that are deleted. we delete them in the background thread
         mutable stdx::mutex _droppedPrefixesMutex;
         std::unordered_set<uint32_t> _droppedPrefixes;
+        std::atomic<uint32_t> _droppedPrefixesCount;
 
         static const std::string kDroppedPrefix;
     };

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -123,70 +123,6 @@ namespace mongo {
             return std::string(reinterpret_cast<const char*>(&bigEndianPrefix), sizeof(uint32_t));
         }
 
-        class PrefixDeletingCompactionFilter : public rocksdb::CompactionFilter {
-        public:
-            explicit PrefixDeletingCompactionFilter(std::unordered_set<uint32_t> droppedPrefixes)
-                : _droppedPrefixes(std::move(droppedPrefixes)),
-                  _prefixCache(0),
-                  _droppedCache(false) {}
-
-            // filter is not called from multiple threads simultaneously
-            virtual bool Filter(int level, const rocksdb::Slice& key,
-                                const rocksdb::Slice& existing_value, std::string* new_value,
-                                bool* value_changed) const {
-                uint32_t prefix = 0;
-                if (!extractPrefix(key, &prefix)) {
-                    // this means there is a key in the database that's shorter than 4 bytes. this
-                    // should never happen and this is a corruption. however, it's not compaction
-                    // filter's job to report corruption, so we just silently continue
-                    return false;
-                }
-                if (prefix == _prefixCache) {
-                    return _droppedCache;
-                }
-                _prefixCache = prefix;
-                _droppedCache = _droppedPrefixes.find(prefix) != _droppedPrefixes.end();
-                return _droppedCache;
-            }
-
-            // IgnoreSnapshots is available since RocksDB 4.3
-#if defined(ROCKSDB_MAJOR) && (ROCKSDB_MAJOR > 4 || (ROCKSDB_MAJOR == 4 && ROCKSDB_MINOR >= 3))
-            virtual bool IgnoreSnapshots() const override { return true; }
-#endif
-
-            virtual const char* Name() const { return "PrefixDeletingCompactionFilter"; }
-
-        private:
-            std::unordered_set<uint32_t> _droppedPrefixes;
-            mutable uint32_t _prefixCache;
-            mutable bool _droppedCache;
-        };
-
-        class PrefixDeletingCompactionFilterFactory : public rocksdb::CompactionFilterFactory {
-        public:
-            explicit
-            PrefixDeletingCompactionFilterFactory(const RocksEngine* engine) : _engine(engine) {}
-
-            virtual std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
-                const rocksdb::CompactionFilter::Context& context) override {
-                auto droppedPrefixes = _engine->getCompactionScheduler()->getDroppedPrefixes();
-                if (droppedPrefixes.size() == 0) {
-                    // no compaction filter needed
-                    return std::unique_ptr<rocksdb::CompactionFilter>(nullptr);
-                } else {
-                    return std::unique_ptr<rocksdb::CompactionFilter>(
-                        new PrefixDeletingCompactionFilter(std::move(droppedPrefixes)));
-                }
-            }
-
-            virtual const char* Name() const override {
-                return "PrefixDeletingCompactionFilterFactory";
-            }
-
-        private:
-            const RocksEngine* _engine;
-        };
-
         // ServerParameter to limit concurrency, to prevent thousands of threads running
         // concurrent searches and thus blocking the entire DB.
         class RocksTicketServerParameter : public ServerParameter {
@@ -261,6 +197,9 @@ namespace mongo {
             _statistics = rocksdb::CreateDBStatistics();
         }
 
+        // used in building options for the db
+        _compactionScheduler.reset(new RocksCompactionScheduler());
+
         // open DB
         rocksdb::DB* db;
         auto s = rocksdb::DB::Open(_options(), path, &db);
@@ -269,7 +208,6 @@ namespace mongo {
 
         _counterManager.reset(
             new RocksCounterManager(_db.get(), rocksGlobalOptions.crashSafeCounters));
-        _compactionScheduler.reset(new RocksCompactionScheduler(_db.get()));
 
         // open iterator
         std::unique_ptr<rocksdb::Iterator> iter(_db->NewIterator(rocksdb::ReadOptions()));
@@ -313,7 +251,8 @@ namespace mongo {
         // reserve prefix+1 for oplog key tracker
         ++_maxPrefix;
 
-        // load dropped prefixes
+        // start compaction thread and load dropped prefixes
+        _compactionScheduler->start(_db.get());
         _compactionScheduler->loadDroppedPrefixes(iter.get());
 
         _durabilityManager.reset(new RocksDurabilityManager(_db.get(), _durable));
@@ -593,7 +532,8 @@ namespace mongo {
         // keep all RocksDB files opened.
         options.max_open_files = -1;
         options.optimize_filters_for_hits = true;
-        options.compaction_filter_factory.reset(new PrefixDeletingCompactionFilterFactory(this));
+        options.compaction_filter_factory.reset(
+            _compactionScheduler->createCompactionFilterFactory());
         options.enable_thread_tracking = true;
 
         options.compression_per_level.resize(3);

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -62,7 +62,7 @@
 #include "mongo/db/server_parameters.h"
 #include "mongo/db/storage/journal_listener.h"
 #include "mongo/db/storage/storage_options.h"
-#include "mongo/platform/endian.h"
+#include "mongo/stdx/memory.h"
 #include "mongo/util/background.h"
 #include "mongo/util/log.h"
 #include "mongo/util/processinfo.h"
@@ -118,11 +118,6 @@ namespace mongo {
     };
 
     namespace {
-        std::string encodePrefix(uint32_t prefix) {
-            uint32_t bigEndianPrefix = endian::nativeToBig(prefix);
-            return std::string(reinterpret_cast<const char*>(&bigEndianPrefix), sizeof(uint32_t));
-        }
-
         // ServerParameter to limit concurrency, to prevent thousands of threads running
         // concurrent searches and thus blocking the entire DB.
         class RocksTicketServerParameter : public ServerParameter {

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -118,16 +118,6 @@ namespace mongo {
     };
 
     namespace {
-        // we encode prefixes in big endian because we want to quickly jump to the max prefix
-        // (iter->SeekToLast())
-        bool extractPrefix(const rocksdb::Slice& slice, uint32_t* prefix) {
-            if (slice.size() < sizeof(uint32_t)) {
-                return false;
-            }
-            *prefix = endian::bigToNative(*reinterpret_cast<const uint32_t*>(slice.data()));
-            return true;
-        }
-
         std::string encodePrefix(uint32_t prefix) {
             uint32_t bigEndianPrefix = endian::nativeToBig(prefix);
             return std::string(reinterpret_cast<const char*>(&bigEndianPrefix), sizeof(uint32_t));
@@ -179,7 +169,7 @@ namespace mongo {
 
             virtual std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
                 const rocksdb::CompactionFilter::Context& context) override {
-                auto droppedPrefixes = _engine->getDroppedPrefixes();
+                auto droppedPrefixes = _engine->getCompactionScheduler()->getDroppedPrefixes();
                 if (droppedPrefixes.size() == 0) {
                     // no compaction filter needed
                     return std::unique_ptr<rocksdb::CompactionFilter>(nullptr);
@@ -245,7 +235,6 @@ namespace mongo {
 
     // first four bytes are the default prefix 0
     const std::string RocksEngine::kMetadataPrefix("\0\0\0\0metadata-", 12);
-    const std::string RocksEngine::kDroppedPrefix("\0\0\0\0droppedprefix-", 18);
 
     RocksEngine::RocksEngine(const std::string& path, bool durable)
         : _path(path), _durable(durable), _maxPrefix(0) {
@@ -325,44 +314,7 @@ namespace mongo {
         ++_maxPrefix;
 
         // load dropped prefixes
-        {
-            int dropped_count = 0;
-            for (iter->Seek(kDroppedPrefix);
-                 iter->Valid() && iter->key().starts_with(kDroppedPrefix); iter->Next()) {
-                invariantRocksOK(iter->status());
-                rocksdb::Slice prefix(iter->key());
-                std::string prefixkey(prefix.ToString());
-                prefix.remove_prefix(kDroppedPrefix.size());
-
-                // let's instruct the compaction scheduler to compact dropped prefix
-                ++dropped_count;
-                uint32_t int_prefix;
-                bool ok = extractPrefix(prefix, &int_prefix);
-                invariant(ok);
-                {
-                    stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-                    _droppedPrefixes.insert(int_prefix);
-                }
-                LOG(1) << "compacting dropped prefix: " << prefix.ToString(true);
-                auto s = _compactionScheduler->compactDroppedPrefix(
-                            prefix.ToString(),
-                            [=] (bool opSucceeded) {
-                                {
-                                    stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-                                    _droppedPrefixes.erase(int_prefix);
-                                }
-                                if (opSucceeded) {
-                                    rocksdb::WriteOptions syncOptions;
-                                    syncOptions.sync = true;
-                                    _db->Delete(syncOptions, prefixkey);
-                                }
-                            });
-                if (!s.isOK()) {
-                    log() << "failed to schedule compaction for prefix " << prefix.ToString(true);
-                }
-            }
-            log() << dropped_count << " dropped prefixes need compaction";
-        }
+        _compactionScheduler->loadDroppedPrefixes(iter.get());
 
         _durabilityManager.reset(new RocksDurabilityManager(_db.get(), _durable));
 
@@ -486,62 +438,17 @@ namespace mongo {
             prefixesToDrop.push_back(rocksGetNextPrefix(prefixesToDrop[0]));
         }
 
-        // We record the fact that we're deleting this prefix. That way we ensure that the prefix is
-        // always deleted
-        for (const auto& prefix : prefixesToDrop) {
-            wb.Put(kDroppedPrefix + prefix, "");
-        }
-
         // we need to make sure this is on disk before starting to delete data in compactions
         rocksdb::WriteOptions syncOptions;
         syncOptions.sync = true;
-        auto s = _db->Write(syncOptions, &wb);
-        if (!s.ok()) {
-            return rocksToMongoStatus(s);
-        }
+        auto s = _compactionScheduler->dropPrefixesAtomic(prefixesToDrop, syncOptions, wb);
 
-        // remove from map
-        {
+        if (s.isOK()) {
+            // remove from map
             stdx::lock_guard<stdx::mutex> lk(_identPrefixMapMutex);
             _identPrefixMap.erase(ident);
         }
-
-        // instruct compaction filter to start deleting
-        {
-            stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-            for (const auto& prefix : prefixesToDrop) {
-                uint32_t int_prefix;
-                bool ok = extractPrefix(prefix, &int_prefix);
-                invariant(ok);
-                _droppedPrefixes.insert(int_prefix);
-            }
-        }
-
-        // Suggest compaction for the prefixes that we need to drop, So that
-        // we free space as fast as possible.
-        for (auto& prefix : prefixesToDrop) {
-            auto s = _compactionScheduler->compactDroppedPrefix(
-                        prefix,
-                        [=] (bool opSucceeded) {
-                            {
-                                uint32_t int_prefix;
-                                bool ok = extractPrefix(prefix, &int_prefix);
-                                invariant(ok);
-                                stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-                                _droppedPrefixes.erase(int_prefix);
-                            }
-                            if (opSucceeded) {
-                                rocksdb::WriteOptions syncOptions;
-                                syncOptions.sync = true;
-                                _db->Delete(syncOptions, kDroppedPrefix + prefix);
-                            }
-                        });
-            if (!s.isOK()) {
-                log() << "failed to schedule compaction for prefix " << rocksdb::Slice(prefix).ToString(true);
-            }
-        }
-
-        return Status::OK();
+        return s;
     }
 
     bool RocksEngine::hasIdent(OperationContext* opCtx, StringData ident) const {
@@ -622,13 +529,6 @@ namespace mongo {
         }
         delete checkpoint;
         return rocksToMongoStatus(s);
-    }
-
-    std::unordered_set<uint32_t> RocksEngine::getDroppedPrefixes() const {
-        stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-        // this will copy the set. that way compaction filter has its own copy and doesn't need to
-        // worry about thread safety
-        return _droppedPrefixes;
     }
 
     // non public api

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -33,7 +33,6 @@
 #include <map>
 #include <string>
 #include <memory>
-#include <unordered_set>
 
 #include <boost/optional.hpp>
 
@@ -149,7 +148,6 @@ namespace mongo {
         const rocksdb::DB* getDB() const { return _db.get(); }
         size_t getBlockCacheUsage() const { return _block_cache->GetUsage(); }
         std::shared_ptr<rocksdb::Cache> getBlockCache() { return _block_cache; }
-        std::unordered_set<uint32_t> getDroppedPrefixes() const;
 
         RocksTransactionEngine* getTransactionEngine() { return &_transactionEngine; }
 
@@ -197,10 +195,6 @@ namespace mongo {
         // mapping from ident --> collection object
         StringMap<RocksRecordStore*> _identCollectionMap;
 
-        // set of all prefixes that are deleted. we delete them in the background thread
-        mutable stdx::mutex _droppedPrefixesMutex;
-        std::unordered_set<uint32_t> _droppedPrefixes;
-
         // This is for concurrency control
         RocksTransactionEngine _transactionEngine;
 
@@ -212,7 +206,6 @@ namespace mongo {
         std::unique_ptr<RocksCompactionScheduler> _compactionScheduler;
 
         static const std::string kMetadataPrefix;
-        static const std::string kDroppedPrefix;
 
         std::unique_ptr<RocksDurabilityManager> _durabilityManager;
         class RocksJournalFlusher;

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -115,7 +115,8 @@ namespace mongo {
     }
 
     Status RocksCompactServerParameter::setFromString(const std::string& str) {
-        return _engine->getCompactionScheduler()->compactAll();
+        _engine->getCompactionScheduler()->compactAll();
+        return Status::OK();
     }
 
     RocksCacheSizeParameter::RocksCacheSizeParameter(RocksEngine* engine)

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -631,12 +631,12 @@ namespace mongo {
                 _oplogSinceLastCompaction.reset();
                 // schedule compaction for oplog
                 std::string oldestAliveKey(_makePrefixedKey(_prefix, _cappedOldestKeyHint));
-                _compactionScheduler->compactRange(_prefix, oldestAliveKey);
+                _compactionScheduler->compactOplog(_prefix, oldestAliveKey);
 
                 // schedule compaction for oplog tracker
                 std::string oplogKeyTrackerPrefix(rocksGetNextPrefix(_prefix));
                 oldestAliveKey = _makePrefixedKey(oplogKeyTrackerPrefix, _cappedOldestKeyHint);
-                _compactionScheduler->compactRange(oplogKeyTrackerPrefix, oldestAliveKey);
+                _compactionScheduler->compactOplog(oplogKeyTrackerPrefix, oldestAliveKey);
 
                 _oplogKeyTracker->resetDeletedSinceCompaction();
             }

--- a/src/rocks_record_store_test.cpp
+++ b/src/rocks_record_store_test.cpp
@@ -64,7 +64,8 @@ namespace mongo {
             _db.reset(db);
             _counterManager.reset(new RocksCounterManager(_db.get(), true));
             _durabilityManager.reset(new RocksDurabilityManager(_db.get(), true));
-            _compactionScheduler.reset(new RocksCompactionScheduler(_db.get()));
+            _compactionScheduler.reset(new RocksCompactionScheduler());
+            _compactionScheduler->start(_db.get());
         }
 
         virtual std::unique_ptr<RecordStore> newNonCappedRecordStore() {

--- a/src/rocks_util.cpp
+++ b/src/rocks_util.cpp
@@ -35,6 +35,11 @@
 #include "mongo/platform/endian.h"
 
 namespace mongo {
+    std::string encodePrefix(uint32_t prefix) {
+        uint32_t bigEndianPrefix = endian::nativeToBig(prefix);
+        return std::string(reinterpret_cast<const char*>(&bigEndianPrefix), sizeof(uint32_t));
+    }
+
     // we encode prefixes in big endian because we want to quickly jump to the max prefix
     // (iter->SeekToLast())
     bool extractPrefix(const rocksdb::Slice& slice, uint32_t* prefix) {

--- a/src/rocks_util.cpp
+++ b/src/rocks_util.cpp
@@ -32,7 +32,18 @@
 #include <string>
 #include <rocksdb/status.h>
 
+#include "mongo/platform/endian.h"
+
 namespace mongo {
+    // we encode prefixes in big endian because we want to quickly jump to the max prefix
+    // (iter->SeekToLast())
+    bool extractPrefix(const rocksdb::Slice& slice, uint32_t* prefix) {
+        if (slice.size() < sizeof(uint32_t)) {
+            return false;
+        }
+        *prefix = endian::bigToNative(*reinterpret_cast<const uint32_t*>(slice.data()));
+        return true;
+    }
 
     Status rocksToMongoStatus_slow(const rocksdb::Status& status, const char* prefix) {
         if (status.ok()) {

--- a/src/rocks_util.h
+++ b/src/rocks_util.h
@@ -48,6 +48,7 @@ namespace mongo {
         return nextPrefix;
     }
 
+    std::string encodePrefix(uint32_t prefix);
     bool extractPrefix(const rocksdb::Slice& slice, uint32_t* prefix);
 
     Status rocksToMongoStatus_slow(const rocksdb::Status& status, const char* prefix);

--- a/src/rocks_util.h
+++ b/src/rocks_util.h
@@ -48,6 +48,8 @@ namespace mongo {
         return nextPrefix;
     }
 
+    bool extractPrefix(const rocksdb::Slice& slice, uint32_t* prefix);
+
     Status rocksToMongoStatus_slow(const rocksdb::Status& status, const char* prefix);
 
     /**


### PR DESCRIPTION
1. Compaction-related code is grouped into RocksCompactionScheduler.
2. Add compaction of dropped prefixes markers.
3. Prioritize different types of compactions.

Jenkins job: http://jenkins.percona.com/view/PSMDB-3.2/job/percona-server-for-mongodb-3.2-param/55/