### PR TITLE
Use boost/regex.hpp explicitly

### DIFF
--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -34,13 +34,13 @@
 
 #include "rocks_server_status.h"
 
+#include "boost/regex.hpp"
 #include "boost/scoped_ptr.hpp"
 
 #include <rocksdb/db.h>
 
 #include "mongo/base/checked_cast.h"
 #include "mongo/bson/bsonobjbuilder.h"
-#include "mongo/stdx/regex.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/scopeguard.h"
 
@@ -50,6 +50,12 @@
 
 namespace mongo {
     using std::string;
+
+    namespace stdx {
+        using boost::regex;
+        using boost::regex_match;
+        using boost::smatch;
+    } // namespace stdx
 
     namespace {
         std::string PrettyPrintBytes(size_t bytes) {


### PR DESCRIPTION
Referencing to mongo/stdx/regex.h breaks build for users who use vanilla MongoDB sources and not PSMDB.

Fixes build broken by https://github.com/percona/mongo-rocks/pull/72