### PR TITLE
PSMDB-164 Ignore missing ident in dropIdent

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -360,12 +360,20 @@ namespace mongo {
 
     // cannot be rolled back
     Status RocksEngine::dropIdent(OperationContext* opCtx, StringData ident) {
+        auto identPrefix = _tryGetIdentPrefix(ident);
+        // happens rarely when dropped prefix markers are persisted but metadata changes
+        // are lost due to system crash on standalone with default acknowledgement behavior
+        if (identPrefix.empty()) {
+            log() << "Cannot find ident " << ident << " to drop, ignoring";
+            return Status::OK();
+        }
+
         rocksdb::WriteBatch wb;
         wb.Delete(kMetadataPrefix + ident.toString());
 
         // calculate which prefixes we need to drop
         std::vector<std::string> prefixesToDrop;
-        prefixesToDrop.push_back(_getIdentPrefix(ident));
+        prefixesToDrop.push_back(identPrefix);
         if (_oplogIdent == ident.toString()) {
             // if we're dropping oplog, we also need to drop keys from RocksOplogKeyTracker (they
             // are stored at prefix+1)
@@ -500,6 +508,13 @@ namespace mongo {
         auto prefixIter = _identPrefixMap.find(ident);
         invariant(prefixIter != _identPrefixMap.end());
         return encodePrefix(prefixIter->second);
+    }
+
+    std::string RocksEngine::_tryGetIdentPrefix(StringData ident) {
+        stdx::lock_guard<stdx::mutex> lk(_identPrefixMapMutex);
+        auto prefixIter = _identPrefixMap.find(ident);
+        const bool prefixFound = (prefixIter != _identPrefixMap.end());
+        return prefixFound ? encodePrefix(prefixIter->second) : std::string();
     }
 
     rocksdb::Options RocksEngine::_options() const {

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -165,6 +165,7 @@ namespace mongo {
     private:
         Status _createIdentPrefix(StringData ident);
         std::string _getIdentPrefix(StringData ident);
+        std::string _tryGetIdentPrefix(StringData ident);
 
         rocksdb::Options _options() const;
 


### PR DESCRIPTION
It may happen that ident has already been dropped and this info
persisted separately, but upper layer metadata didn't persist because
of system crash on standalone instance with default acknowledgement
behavior.

Jenkins job: http://jenkins.percona.com/view/PSMDB-3.2/job/percona-server-for-mongodb-3.2-param/91/