### PR TITLE
PSMDB-164 Ignore missing ident in dropIdent

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -379,12 +379,20 @@ namespace mongo {
 
     // cannot be rolled back
     Status RocksEngine::dropIdent(OperationContext* opCtx, StringData ident) {
+        auto config = _tryGetIdentConfig(ident);
+        // happens rarely when dropped prefix markers are persisted but metadata changes
+        // are lost due to system crash on standalone with default acknowledgement behavior
+        if (config.isEmpty()) {
+            log() << "Cannot find ident " << ident << " to drop, ignoring";
+            return Status::OK();
+        }
+
         rocksdb::WriteBatch wb;
         wb.Delete(kMetadataPrefix + ident.toString());
 
         // calculate which prefixes we need to drop
         std::vector<std::string> prefixesToDrop;
-        prefixesToDrop.push_back(_extractPrefix(_getIdentConfig(ident)));
+        prefixesToDrop.push_back(_extractPrefix(config));
         if (_oplogIdent == ident.toString()) {
             // if we're dropping oplog, we also need to drop keys from RocksOplogKeyTracker (they
             // are stored at prefix+1)
@@ -521,6 +529,13 @@ namespace mongo {
         auto identIter = _identMap.find(ident);
         invariant(identIter != _identMap.end());
         return identIter->second.copy();
+    }
+
+    BSONObj RocksEngine::_tryGetIdentConfig(StringData ident) {
+        stdx::lock_guard<stdx::mutex> lk(_identMapMutex);
+        auto identIter = _identMap.find(ident);
+        const bool identFound = (identIter != _identMap.end());
+        return identFound ? identIter->second.copy() : BSONObj();
     }
 
     std::string RocksEngine::_extractPrefix(const BSONObj& config) {

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -168,6 +168,7 @@ namespace mongo {
     private:
         Status _createIdent(StringData ident, BSONObjBuilder* configBuilder);
         BSONObj _getIdentConfig(StringData ident);
+        BSONObj _tryGetIdentConfig(StringData ident);
         std::string _extractPrefix(const BSONObj& config);
 
         rocksdb::Options _options() const;


### PR DESCRIPTION
It may happen that ident has already been dropped and this info
persisted separately, but upper layer metadata didn't persist because
of system crash on standalone instance with default acknowledgement
behavior.