### PR TITLE
Fix checkreploplog v34

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -1154,6 +1154,7 @@ namespace mongo {
     }
 
     boost::optional<Record> RocksRecordStore::Cursor::seekExact(const RecordId& id) {
+        _oplogHackRestoreBeforeNext = false;
         _needFirstSeek = false;
         _skipNextAdvance = false;
         _iterator.reset();

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -1066,7 +1066,7 @@ namespace mongo {
         _currentSequenceNumber =
           RocksRecoveryUnit::getRocksRecoveryUnit(txn)->snapshot()->GetSequenceNumber();
           
-        if (!startIterator.isNull()) {
+        if (!startIterator.isNull() && !_readUntilForOplog.isNull()) {
             // This is a hack to speed up first/last record retrieval from the oplog
             _needFirstSeek = false;
             _lastLoc = startIterator;

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -1065,14 +1065,13 @@ namespace mongo {
           _readUntilForOplog(RocksRecoveryUnit::getRocksRecoveryUnit(txn)->getOplogReadTill()) {
         _currentSequenceNumber =
           RocksRecoveryUnit::getRocksRecoveryUnit(txn)->snapshot()->GetSequenceNumber();
-          
-        if (!startIterator.isNull() && !_readUntilForOplog.isNull()) {
+
+        if (!startIterator.isNull()) {
             // This is a hack to speed up first/last record retrieval from the oplog
+            _oplogHackRestoreBeforeNext = true;
             _needFirstSeek = false;
             _lastLoc = startIterator;
-            iterator();
-            _skipNextAdvance = true;
-            _eof = false;
+            restore();
         }
     }
 
@@ -1125,6 +1124,7 @@ namespace mongo {
     }
 
     boost::optional<Record> RocksRecordStore::Cursor::next() {
+        _oplogHackRestoreBeforeNext = false;
         if (_eof) {
             return {};
         }
@@ -1186,12 +1186,18 @@ namespace mongo {
             _currentSequenceNumber = ru->snapshot()->GetSequenceNumber();
         }
 
-        _skipNextAdvance = false;
+        if (_eof || _needFirstSeek) {
+            _skipNextAdvance = false;
+            return true;
+        }
 
-        if (_eof) return true;
-        if (_needFirstSeek) return true;
-
+        // _skipNextAdvance is reset by positionIterator()
+        // but in oplog first record retrieval hack case another logic is in use
         positionIterator();
+        if (_oplogHackRestoreBeforeNext) {
+            _skipNextAdvance = true;
+            _eof = false;
+        }
         // Return false if the collection is capped and we reached an EOF. Otherwise return true.
         return _cappedVisibilityManager && _eof ? false : true;
     }

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -252,7 +252,8 @@ namespace mongo {
             RecordId _lastLoc;
             std::unique_ptr<rocksdb::Iterator> _iterator;
             std::string _seekExactResult;
-            // true between oplog first record retrieval hack start and first next() call
+            // true between oplog first record retrieval hack start and first
+            // positioning call (next(), seekExact())
             bool _oplogHackRestoreBeforeNext = false;
             void positionIterator();
             rocksdb::Iterator* iterator();

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -252,6 +252,8 @@ namespace mongo {
             RecordId _lastLoc;
             std::unique_ptr<rocksdb::Iterator> _iterator;
             std::string _seekExactResult;
+            // true between oplog first record retrieval hack start and first next() call
+            bool _oplogHackRestoreBeforeNext = false;
             void positionIterator();
             rocksdb::Iterator* iterator();
         };


### PR DESCRIPTION
medium test: http://jenkins.percona.com/view/PSMDB-3.4/job/percona-server-for-mongodb-3.4-param/105/
big test: http://jenkins.percona.com/view/PSMDB-3.4/job/percona-server-for-mongodb-3.4-param/106/
there is an issue with `replica_sets/rollback_views` but:
- it also fails without the fix (see here: http://jenkins.percona.com/view/PSMDB-3.4/job/percona-server-for-mongodb-3.4-param/108/)
- it does not fail outside of jenkins (on other machine)
so it seems to be unrelated