### PR TITLE
SERVER-30790: Have RocksServerStatusSection take a Global IS lock

### DIFF
--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -42,6 +42,7 @@
 
 #include "mongo/base/checked_cast.h"
 #include "mongo/bson/bsonobjbuilder.h"
+#include "mongo/db/concurrency/d_concurrency.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/scopeguard.h"
 
@@ -455,6 +456,7 @@ namespace mongo {
 
     BSONObj RocksServerStatusSection::generateSection(OperationContext* txn,
                                                       const BSONElement& configElement) const {
+        Lock::GlobalLock lk(txn->lockState(), LockMode::MODE_IS, UINT_MAX);
 
         BSONObjBuilder bob;
 


### PR DESCRIPTION
(cherry picked from commit 92df9749847fd723bc12645b3e98c97f8bda1265)