### PR TITLE
SERVER-19213  clean up invariants around snapshot creation

### DIFF
--- a/src/rocks_snapshot_manager.cpp
+++ b/src/rocks_snapshot_manager.cpp
@@ -49,7 +49,7 @@ namespace mongo {
         stdx::lock_guard<stdx::mutex> lock(_mutex);
 
         uint64_t nameU64 = name.asU64();
-        invariant(!_committedSnapshot || *_committedSnapshot < nameU64);
+        invariant(!_committedSnapshot || *_committedSnapshot <= nameU64);
         _committedSnapshot = nameU64;
     }
 


### PR DESCRIPTION
this is mongo-rocks port of commit 512ae2b48672
it fixes invariant failures in 3.6.0-rc0 and newer