### PR TITLE
PSMDB 185. Fix timestamp reordering

### DIFF
--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -406,7 +406,7 @@ namespace mongo {
             if (_snapshotHolder.get() == nullptr) {
                 _snapshotHolder = _snapshotManager->getCommittedSnapshot();
             }
-            return _snapshotHolder->snapshot;
+            return _snapshotHolder.get();
         }
         if (!_snapshot) {
             // RecoveryUnit might be used for writing, so we need to call recordSnapshotId().

--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -296,7 +296,7 @@ namespace mongo {
     boost::optional<Timestamp> RocksRecoveryUnit::getMajorityCommittedSnapshot() const {
         if (!_readFromMajorityCommittedSnapshot)
             return {};
-        return Timestamp(_snapshotManager->getCommittedSnapshot().get()->name);
+        return Timestamp(_snapshotManager->getCommittedSnapshotName());
     }
 
     SnapshotId RocksRecoveryUnit::getSnapshotId() const { return SnapshotId(_mySnapshotId); }

--- a/src/rocks_recovery_unit.h
+++ b/src/rocks_recovery_unit.h
@@ -205,7 +205,7 @@ namespace mongo {
 
         // If we read from a committed snapshot, then ownership of the snapshot
         // should be shared here to ensure that it is not released early
-        std::shared_ptr<RocksSnapshotManager::SnapshotHolder> _snapshotHolder;
+        RocksSnapshotManager::SnapshotHolder _snapshotHolder;
 
         bool _readFromMajorityCommittedSnapshot = false;
         bool _areWriteUnitOfWorksBanned = false;

--- a/src/rocks_snapshot_manager.h
+++ b/src/rocks_snapshot_manager.h
@@ -45,13 +45,7 @@ class RocksSnapshotManager final : public SnapshotManager {
     MONGO_DISALLOW_COPYING(RocksSnapshotManager);
 
 public:
-    struct SnapshotHolder {
-        rocksdb::DB* db;
-        const rocksdb::Snapshot* snapshot;
-
-        SnapshotHolder(rocksdb::DB* db_, const rocksdb::Snapshot* snapshot_);
-        ~SnapshotHolder();
-    };
+    typedef std::shared_ptr<const rocksdb::Snapshot> SnapshotHolder;
 
     RocksSnapshotManager(rocksdb::DB* db) : _db(db) {}
 
@@ -71,14 +65,15 @@ public:
     bool haveCommittedSnapshot() const;
 
     uint64_t getCommittedSnapshotName() const;
-    std::shared_ptr<RocksSnapshotManager::SnapshotHolder> getCommittedSnapshot() const;
+    RocksSnapshotManager::SnapshotHolder getCommittedSnapshot() const;
 
     void insertSnapshot(const Timestamp timestamp);
 
 private:
     void assertCommittedSnapshot_inlock() const;
+    SnapshotHolder createSnapshot();
 
-    typedef std::map<uint64_t, std::shared_ptr<SnapshotHolder>> SnapshotMap;
+    typedef std::map<uint64_t, SnapshotHolder> SnapshotMap;
 
     SnapshotMap _snapshotMap;
     boost::optional<uint64_t> _committedSnapshot;

--- a/src/rocks_snapshot_manager.h
+++ b/src/rocks_snapshot_manager.h
@@ -83,6 +83,7 @@ private:
     SnapshotMap _snapshotMap;
     boost::optional<uint64_t> _committedSnapshot;
     SnapshotMap::iterator _committedSnapshotIter; // Cached iterator to current committed snapshot
+    uint64_t _maxSeenSnapshot = 0;
 
     mutable stdx::mutex _mutex;  // Guards all members
     rocksdb::DB* _db = nullptr;  // not owned

--- a/src/rocks_snapshot_manager.h
+++ b/src/rocks_snapshot_manager.h
@@ -46,10 +46,10 @@ class RocksSnapshotManager final : public SnapshotManager {
 
 public:
     struct SnapshotHolder {
-        uint64_t name;
-        const rocksdb::Snapshot* snapshot;
         rocksdb::DB* db;
-        SnapshotHolder(rocksdb::DB* db_, const rocksdb::Snapshot* snapshot_, uint64_t name_);
+        const rocksdb::Snapshot* snapshot;
+
+        SnapshotHolder(rocksdb::DB* db_, const rocksdb::Snapshot* snapshot_);
         ~SnapshotHolder();
     };
 
@@ -70,11 +70,14 @@ public:
 
     bool haveCommittedSnapshot() const;
 
+    uint64_t getCommittedSnapshotName() const;
     std::shared_ptr<RocksSnapshotManager::SnapshotHolder> getCommittedSnapshot() const;
 
     void insertSnapshot(const Timestamp timestamp);
 
 private:
+    void assertCommittedSnapshot_inlock() const;
+
     typedef std::map<uint64_t, std::shared_ptr<SnapshotHolder>> SnapshotMap;
 
     SnapshotMap _snapshotMap;


### PR DESCRIPTION
Please review commit-by-commit because:
- only the 2nd commit directly fixes the problem
- the 1st commit removes timestamp from `SnapshotHolder` so we can share holders w/o need to fix their internal timestamps (and actually those timestamps are excessive as we keep them as keys in `_snapshotMap`)
- the 3rd commit removes unneeded entity by delegating snapshot releasing to the deleter of `std::shared_ptr`.

Jenkins job: https://jenkins.percona.com/view/PSMDB-3.6/job/percona-server-for-mongodb-3.6-param/44/

Let's wait on big one before merging: https://jenkins.percona.com/view/PSMDB-3.6/job/percona-server-for-mongodb-3.6-param/45/